### PR TITLE
fix: buf workflow used a wrong path for finding the proto files

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -15,16 +15,16 @@ jobs:
       - uses: bufbuild/buf-setup-action@v1
       - uses: bufbuild/buf-lint-action@v1
         with:
-          input: proto
+          input: api/proto
       - uses: bufbuild/buf-breaking-action@v1
         with:
-          input: proto
+          input: api/proto
       - name: Pushing to BSR
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: bufbuild/buf-push-action@v1
         with:
           buf_token: ${{ secrets.BUF_BSR_TOKEN }}
-          input: proto
+          input: api/proto
       - name: Report failure
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions-cool/issues-helper@v3


### PR DESCRIPTION
This PR fixes a bug where the `buf` workflow used the wrong path for finding the proto files.