### PR TITLE
ci: fix buf breaking

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: bufbuild/buf-breaking-action@v1
         with:
           input: api/proto
+          against: .git#branch=master,subdir=api/proto
       - name: Pushing to BSR
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: bufbuild/buf-push-action@v1


### PR DESCRIPTION
Fix `buf breaking`. Add missing parameters to make it work

It should detect now breaking changes in the proto