### PR TITLE
Fix: docker build is failing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ ARG VERSION
 
 ### Build
 FROM golang:1.19 AS build
+ARG TARGETOS
+ARG TARGETARCH
+ARG LDFLAGS
 
 WORKDIR /workspace
 COPY go.mod /workspace
@@ -17,6 +20,7 @@ FROM build AS build-core
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="${LDFLAGS}" -o /out/core cmd/core/*.go
 
 FROM gcr.io/distroless/static:nonroot as core
+ARG VERSION
 
 LABEL org.opencontainers.image.source="https://github.com/raptor-ml/raptor"
 LABEL org.opencontainers.image.version="${VERSION}"

--- a/Makefile
+++ b/Makefile
@@ -169,27 +169,27 @@ docker-build-runtimes: generate ## Build docker images for runtimes.
 		--build-arg BASE_PYTHON_IMAGE="python:3.11-alpine"\
 		-t ${RUNTIME_IMG_BASE}:${VERSION}-python3.11 -t ${RUNTIME_IMG_BASE}:latest-python3.11 \
 		-t ${RUNTIME_IMG_BASE}:${VERSION} -t ${RUNTIME_IMG_BASE}:latest \
-		--target runtime .
+		--target runtime -f ./runtime/Dockerfile .
 
 	DOCKER_BUILDKIT=1 docker build --build-arg VERSION="${VERSION}" \
 		--build-arg BASE_PYTHON_IMAGE="python:3.10-alpine"\
 		-t ${RUNTIME_IMG_BASE}:${VERSION}-python3.10 -t ${RUNTIME_IMG_BASE}:latest-python3.10 \
-		--target runtime .
+		--target runtime -f ./runtime/Dockerfile .
 
 	DOCKER_BUILDKIT=1 docker build --build-arg VERSION="${VERSION}" \
 		--build-arg BASE_PYTHON_IMAGE="python:3.9-alpine"\
 		-t ${RUNTIME_IMG_BASE}:${VERSION}-python3.9 -t ${RUNTIME_IMG_BASE}:latest-python3.9 \
-		--target runtime .
+		--target runtime -f ./runtime/Dockerfile .
 
 	DOCKER_BUILDKIT=1 docker build --build-arg VERSION="${VERSION}" \
 		--build-arg BASE_PYTHON_IMAGE="python:3.8-alpine"\
 		-t ${RUNTIME_IMG_BASE}:${VERSION}-python3.8 -t ${RUNTIME_IMG_BASE}:latest-python3.8 \
-		--target runtime .
+		--target runtime -f ./runtime/Dockerfile .
 
 	DOCKER_BUILDKIT=1 docker build --build-arg VERSION="${VERSION}" \
 		--build-arg BASE_PYTHON_IMAGE="python:3.7-alpine"\
 		-t ${RUNTIME_IMG_BASE}:${VERSION}-python3.7 -t ${RUNTIME_IMG_BASE}:latest-python3.7 \
-		--target runtime .
+		--target runtime -f ./runtime/Dockerfile .
 
 .PHONY: kind-load
 kind-load: ## Load docker images into kind.

--- a/cmd/core/internal/setup/raptor.go
+++ b/cmd/core/internal/setup/raptor.go
@@ -92,7 +92,7 @@ func coreControllers(mgr manager.Manager, eng api.ManagerEngine) {
 	OrFail(err, "unable to create core controller", "controller", "FeatureSet")
 }
 
-func operatorControllers(mgr manager.Manager, rm runtimemanager.RuntimeManager) {
+func operatorControllers(mgr manager.Manager, rm api.RuntimeManager) {
 	var err error
 
 	coreAddr := viper.GetString("accessor-service")

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -2,13 +2,21 @@ ARG BASE_PYTHON_IMAGE=python:3.11-alpine
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
 ARG VERSION
+ARG GRPC_HEALTH_PROBE_VERSION=v0.4.14
 
+## Build protobuf files
 FROM bufbuild/buf:1.9.0 as buf
 WORKDIR /workspace
-COPY ../api/proto /workspace
+COPY ./api/proto /workspace
 RUN buf generate --include-imports .
 
+## Runtime image
+
 FROM ${BASE_PYTHON_IMAGE} as runtime
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION
+ARG GRPC_HEALTH_PROBE_VERSION
 
 LABEL org.opencontainers.image.source="https://github.com/raptor-ml/raptor"
 LABEL org.opencontainers.image.version="${VERSION}"
@@ -16,17 +24,16 @@ LABEL org.opencontainers.image.url="https://raptor.ml"
 LABEL org.opencontainers.image.title="Raptor Runtime"
 LABEL org.opencontainers.image.description="Raptor Runtime is a sidecar that provides tooling for Raptor extensions"
 
+RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-${TARGETOS}-${TARGETARCH} && \
+    chmod +x /bin/grpc_health_probe
+
 RUN pip install --upgrade pip
 
 WORKDIR /runtime
-COPY . /runtime
+COPY ./runtime /runtime
 COPY --from=buf /workspace/gen/python /runtime/proto
-COPY ../labsdk/raptor/program.py .
+COPY ./labsdk/raptor/program.py .
 
 RUN pip install -r requirements.txt
-
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.14 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-${TARGETOS}-${TARGETARCH} && \
-    chmod +x /bin/grpc_health_probe
 
 CMD [ "python", "./runtime.py" ]


### PR DESCRIPTION
This PR fixes the docker building process actually to work :)
1. Runtime: fix the location to allow relative copies
2. Fixes argument passing
3. Reorder the Runtime docker to create better caching
4. Fixing an issue with a wrong interface reference(fix: fix wrong reference to the `api.RuntimeManager`)