### PR TITLE
fix: shared-volume definition was missing in the core and runnner definitions

### DIFF
--- a/config/core/core.yaml
+++ b/config/core/core.yaml
@@ -100,6 +100,8 @@ spec:
               cpu: 100m
               memory: 200Mi
       volumes:
+        - name: grpc-udp
+          emptyDir: {}
         - name: cert
           secret:
             defaultMode: 420

--- a/pkg/runner/base.go
+++ b/pkg/runner/base.go
@@ -122,6 +122,12 @@ func (r BaseRunner) updateDeployment(deploy *appsv1.Deployment, req api.Reconcil
 			})
 		}
 	}
+	deploy.Spec.Template.Spec.Volumes = append(deploy.Spec.Template.Spec.Volumes, corev1.Volume{
+		Name: "grpc-udp",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	})
 	deploy.Spec.Template.Spec.Containers = append([]corev1.Container{
 		containerWithDefaults(corev1.Container{
 			Image: r.Image,


### PR DESCRIPTION
shared-volume definition was missing in the core and runnner definitions