### PR TITLE
fix: block writes to featuresets (closes #151)

### DIFF
--- a/internal/plugins/builders/featureset/fs.go
+++ b/internal/plugins/builders/featureset/fs.go
@@ -57,6 +57,7 @@ func FeatureApply(fd api.FeatureDescriptor, builder manifests.FeatureBuilder, fa
 
 	fs := &featureset{engine: engine, features: spec.Features}
 	faapi.AddPostGetMiddleware(0, fs.preGetMiddleware)
+	faapi.AddPreSetMiddleware(0, fs.preSetMiddleware)
 	return nil
 }
 
@@ -94,5 +95,11 @@ func (fs *featureset) preGetMiddleware(next api.MiddlewareHandler) api.Middlewar
 		ret.Value = results
 
 		return ret, nil
+	}
+}
+
+func (fs *featureset) preSetMiddleware(next api.MiddlewareHandler) api.MiddlewareHandler {
+	return func(ctx context.Context, fd api.FeatureDescriptor, keys api.Keys, val api.Value) (api.Value, error) {
+		return val, fmt.Errorf("cannot set featureset %s", fd.FQN)
 	}
 }


### PR DESCRIPTION
This PR closes the issue that was described in #151 

It blocks write requests to FeatureSet simply by adding a pre-set middleware :)