### PR TITLE
fix: e2e tests improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+Makefile
+.github
+.git
+.venv
+.run
+.idea
+bin/
+bundle/
+bundle.Dockerfile
+.golangci.yaml
+internal/e2e/

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -41,7 +41,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Install KiND
-        uses: helm/kind-action@v1.3.0
+        uses: helm/kind-action@v1.5.0
         with:
           install_only: true
       - name: Install Kustomize

--- a/Makefile
+++ b/Makefile
@@ -125,9 +125,9 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 
 .PHONY: buf-build
 buf-build: buf ## Build protobufs with buf
-	$(BUF) build proto
-	$(BUF) breaking proto --against .
-	cd proto && $(BUF) generate
+	cd api/proto && $(BUF) build
+	cd api/proto && $(BUF) breaking --against .
+	cd api/proto && $(BUF) generate
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.
@@ -139,7 +139,7 @@ test: manifests generate fmt lint envtest ## Run tests.
 
 .PHONY: test-e2e
 test-e2e: docker-build ## Run integration tests.
-	go test -v -timeout 1h ./internal/e2e/... -tags e2e --build-tag=$(VERSION) -v 5
+	go test -v -timeout 1h -tags e2e github.com/raptor-ml/raptor/internal/e2e --args -v 5 --build-tag=$(VERSION)
 
 ##@ Build
 
@@ -164,29 +164,29 @@ docker-build: generate docker-build-runtimes ## Build docker images.
 	DOCKER_BUILDKIT=1 docker build --build-arg LDFLAGS="${LDFLAGS}" --build-arg VERSION="${VERSION}" -t ${HISTORIAN_IMG_BASE}:${VERSION} -t ${HISTORIAN_IMG_BASE}:latest --target historian .
 
 .PHONY: docker-build-runtimes
-docker-build-runtimes: generate ## Build docker images for runtimes.
-	DOCKER_BUILDKIT=1 docker build --build-arg VERSION="${VERSION}" \
+docker-build-runtimes: buf-build ## Build docker images for runtimes.
+	DOCKER_DEFAULT_PLATFORM=linux/amd64 DOCKER_BUILDKIT=1 docker build --build-arg VERSION="${VERSION}" \
 		--build-arg BASE_PYTHON_IMAGE="python:3.11-alpine"\
 		-t ${RUNTIME_IMG_BASE}:${VERSION}-python3.11 -t ${RUNTIME_IMG_BASE}:latest-python3.11 \
 		-t ${RUNTIME_IMG_BASE}:${VERSION} -t ${RUNTIME_IMG_BASE}:latest \
 		--target runtime -f ./runtime/Dockerfile .
 
-	DOCKER_BUILDKIT=1 docker build --build-arg VERSION="${VERSION}" \
+	DOCKER_DEFAULT_PLATFORM=linux/amd64 DOCKER_BUILDKIT=1 docker build --build-arg VERSION="${VERSION}" \
 		--build-arg BASE_PYTHON_IMAGE="python:3.10-alpine"\
 		-t ${RUNTIME_IMG_BASE}:${VERSION}-python3.10 -t ${RUNTIME_IMG_BASE}:latest-python3.10 \
 		--target runtime -f ./runtime/Dockerfile .
 
-	DOCKER_BUILDKIT=1 docker build --build-arg VERSION="${VERSION}" \
+	DOCKER_DEFAULT_PLATFORM=linux/amd64 DOCKER_BUILDKIT=1 docker build --build-arg VERSION="${VERSION}" \
 		--build-arg BASE_PYTHON_IMAGE="python:3.9-alpine"\
 		-t ${RUNTIME_IMG_BASE}:${VERSION}-python3.9 -t ${RUNTIME_IMG_BASE}:latest-python3.9 \
 		--target runtime -f ./runtime/Dockerfile .
 
-	DOCKER_BUILDKIT=1 docker build --build-arg VERSION="${VERSION}" \
+	DOCKER_DEFAULT_PLATFORM=linux/amd64 DOCKER_BUILDKIT=1 docker build --build-arg VERSION="${VERSION}" \
 		--build-arg BASE_PYTHON_IMAGE="python:3.8-alpine"\
 		-t ${RUNTIME_IMG_BASE}:${VERSION}-python3.8 -t ${RUNTIME_IMG_BASE}:latest-python3.8 \
 		--target runtime -f ./runtime/Dockerfile .
 
-	DOCKER_BUILDKIT=1 docker build --build-arg VERSION="${VERSION}" \
+	DOCKER_DEFAULT_PLATFORM=linux/amd64 DOCKER_BUILDKIT=1 docker build --build-arg VERSION="${VERSION}" \
 		--build-arg BASE_PYTHON_IMAGE="python:3.7-alpine"\
 		-t ${RUNTIME_IMG_BASE}:${VERSION}-python3.7 -t ${RUNTIME_IMG_BASE}:latest-python3.7 \
 		--target runtime -f ./runtime/Dockerfile .


### PR DESCRIPTION
This PR introduces a few small changes that impact the building of the images and the e2e tests:

1. Reduce building time by adding gitignore
2. Fix paths for e2e tests
3. Fix docker building for M1