### PR TITLE
ci: disable PR body length requirement

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -38,15 +38,15 @@ jobs:
             Please make sure you are NOT addressing multiple issues with one PR.
             Note this PR might be rejected due to its size.
           files_to_ignore: ''
-      - name: "Check for PR body length"
-        shell: bash
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
-        run: |
-            if [ ${#PR_BODY} -lt 80 ]; then
-              echo "::error title=PR body is too short::Your PR is probably isn't descriptive enough.\nYou should give a description that highlights both what you're doing it and *why* you're doing it. Someone reading the PR description without clicking any issue links should be able to roughly understand what's going on."
-              exit 1
-            fi
+#       - name: "Check for PR body length"
+#         shell: bash
+#         env:
+#           PR_BODY: ${{ github.event.pull_request.body }}
+#         run: |
+#             if [ ${#PR_BODY} -lt 80 ]; then
+#               echo "::error title=PR body is too short::Your PR is probably isn't descriptive enough.\nYou should give a description that highlights both what you're doing it and *why* you're doing it. Someone reading the PR description without clicking any issue links should be able to roughly understand what's going on."
+#               exit 1
+#             fi
       - uses: amannn/action-semantic-pull-request@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
PR length body is too demanding for new contributors. For the time being, let's help contributors to contribute without many requirements 🙃

This change disables (by commenting out) the PR body length's requirement for new PRs.